### PR TITLE
Rename 'zVecFreeAO', 'zMatFreeAO' -> 'zVecFreeAtOnce', 'zMatFreeAtOnce' with zm update

### DIFF
--- a/example/autoencoder_test.c
+++ b/example/autoencoder_test.c
@@ -87,6 +87,6 @@ int main(int argc, char *argv[])
 
   nzNetWriteZTK( &nn, SIN_AE_ZTK );
   nzNetDestroy( &nn );
-  zVecFreeAO( 2, input, output );
+  zVecFreeAtOnce( 2, input, output );
   return 0;
 }

--- a/example/sin_test.c
+++ b/example/sin_test.c
@@ -85,6 +85,6 @@ int main(int argc, char *argv[])
 
   nzNetWriteZTK( &nn, SIN_ZTK );
   nzNetDestroy( &nn );
-  zVecFreeAO( 3, input, output, outref );
+  zVecFreeAtOnce( 3, input, output, outref );
   return 0;
 }

--- a/example/xor_cpp_test.cpp
+++ b/example/xor_cpp_test.cpp
@@ -81,6 +81,6 @@ int main(int argc, char *argv[])
   nn.writeZTK( XOR_ZTK );
 
   nn.destroy();
-  zVecFreeAO( 3, input, output, des );
+  zVecFreeAtOnce( 3, input, output, des );
   return 0;
 }

--- a/example/xor_test.c
+++ b/example/xor_test.c
@@ -80,6 +80,6 @@ int main(int argc, char *argv[])
   nzNetWriteZTK( &nn, XOR_ZTK );
 
   nzNetDestroy( &nn );
-  zVecFreeAO( 3, input, output, des );
+  zVecFreeAtOnce( 3, input, output, des );
   return 0;
 }


### PR DESCRIPTION
As the title suggests, some errors occurred, so it was fixed.